### PR TITLE
Change the footer copyright company name

### DIFF
--- a/css/main-responsive.css
+++ b/css/main-responsive.css
@@ -56,4 +56,8 @@
     margin-left: 0;
     margin-bottom: 30px;
   }
+
+  .footer-end {
+    font-size: 12px;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
       <div class="clear"></div>
       <div class="footer-end">
         <p>
-          Copyright 2018 Speargate Inc. All rights reserved
+          Copyright 2019 Warren Financial Technologies Limited.<br /> All rights reserved
         </p>
       </div>
     </footer>


### PR DESCRIPTION
#### What does this PR do?
- Currently, the company name on the footer is `Speargate Inc`. The aim of this task is to change the name.
#### Description of Task to be completed?
- Change the copyright name to `Warren Financial Technologies Limited`
#### How should this be manually tested?
- Pull this branch `change-footer-copyright`
- Navigate to the `index.html` file and scroll down to the bottom of the page
- You should see the change implemented
#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-04-30 at 2 17 47 PM" src="https://user-images.githubusercontent.com/42177767/56964260-c1894580-6b52-11e9-95e5-5d5e10d372a1.png">
